### PR TITLE
Add device type '008' for a window unit AC

### DIFF
--- a/app/Services/ConnectlifeApiService.php
+++ b/app/Services/ConnectlifeApiService.php
@@ -137,7 +137,7 @@ class ConnectlifeApiService
                 continue;
             }
 
-            if (!in_array($device['deviceTypeCode'], ['009', '006'], true)) {
+            if (!in_array($device['deviceTypeCode'], ['009', '006', '008'], true)) {
                 Log::info("Skipping device with unknown type code: $id", $device);
                 continue;
             }


### PR DESCRIPTION
My window unit AC works well with this connector, but it has device type '008', so it was refusing to work as-is. 